### PR TITLE
Template should be able to match on any element not just /

### DIFF
--- a/tests/root-element.test.js
+++ b/tests/root-element.test.js
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import { dom } from 'isomorphic-jsx';
+import { xsltProcess, xmlParse } from '../src'
+
+describe('root-element', () => {
+
+  it('select root element test', () => {
+    const xmlString = <root>
+      <test name="test1" />
+      <test name="test2" />
+      <test name="test3" />
+      <test name="test4" />
+    </root>;
+
+    const xsltString = '<?xml version="1.0"?>' +
+      <xsl:stylesheet version="1.0">
+        <xsl:template match="test">
+          <span> <xsl:value-of select="@name" /> </span>
+        </xsl:template>
+        <xsl:template match="/root">
+          <div>
+            <xsl:apply-templates select="test" />
+          </div>
+        </xsl:template>
+      </xsl:stylesheet>;
+
+    const expectedOutString = <div>
+      <span>test1</span>
+      <span>test2</span>
+      <span>test3</span>
+      <span>test4</span>
+    </div>;
+
+    const outXmlString = xsltProcess(
+      xmlParse(xmlString),
+      xmlParse(xsltString)
+    );
+
+    assert.equal(
+      outXmlString,
+      expectedOutString
+    );
+  })
+
+})


### PR DESCRIPTION
The first matching template must be "/" in this processor. That is incorrect. Any root element can be selected. So this works:
```
<xsl:template match="/">
```

but this doesn't:

```
<xsl:template match="/root">
```

I have added a failing test, but I don't know how to fix this unfortunately.