### PR TITLE
Multiple match bug

### DIFF
--- a/src/dom/xml-functions.ts
+++ b/src/dom/xml-functions.ts
@@ -207,7 +207,7 @@ function xmlTransformedTextRecursive(node: XNode, buffer: any[], options: XmlOut
  * @param buffer The XML buffer.
  * @param cdata If using CDATA configuration.
  */
-function xmlElementLogicTrivial(node: XNode, buffer: any[], options: XmlOutputOptions) {
+function xmlElementLogicTrivial(node: XNode, buffer: string[], options: XmlOutputOptions) {
     buffer.push(`<${xmlFullNodeName(node)}`);
 
     const attributes = node.transformedAttributes || node.attributes;
@@ -223,7 +223,7 @@ function xmlElementLogicTrivial(node: XNode, buffer: any[], options: XmlOutputOp
     }
 
     const childNodes = node.transformedChildNodes.length > 0 ? node.transformedChildNodes : node.childNodes;
-    if (childNodes.length == 0) {
+    if (childNodes.length === 0) {
         buffer.push('/>');
     } else {
         buffer.push('>');

--- a/src/dom/xml-functions.ts
+++ b/src/dom/xml-functions.ts
@@ -180,7 +180,7 @@ function xmlTransformedTextRecursive(node: XNode, buffer: any[], options: XmlOut
             buffer.push(`<![CDATA[${nodeValue}]]>`);
         }
     } else if (nodeType == DOM_COMMENT_NODE) {
-        buffer.push(`<!--${nodeValue}-->`);
+        buffer.push(`<!-- ${nodeValue} -->`);
     } else if (nodeType == DOM_ELEMENT_NODE) {
         // If node didn't have a transformed name, but its children
         // had transformations, children should be present at output.
@@ -217,10 +217,8 @@ function xmlElementLogicTrivial(node: XNode, buffer: any[], options: XmlOutputOp
             continue;
         }
 
-        const attributeNodeName = attribute.transformedNodeName || attribute.nodeName;
-        const attributeNodeValue = attribute.transformedNodeValue || attribute.nodeValue;
-        if (attributeNodeName && attributeNodeValue) {
-            buffer.push(` ${xmlFullNodeName(attribute)}="${xmlEscapeAttr(attributeNodeValue)}"`);
+        if (attribute.transformedNodeName && attribute.transformedNodeValue) {
+            buffer.push(` ${xmlFullNodeName(attribute)}="${xmlEscapeAttr(attribute.transformedNodeValue)}"`);
         }
     }
 

--- a/src/dom/xnode.ts
+++ b/src/dom/xnode.ts
@@ -318,7 +318,10 @@ export class XNode {
             }
         }
 
-        this.transformedAttributes.push(XNode.create(DOM_ATTRIBUTE_NODE, name, value, this));
+        const newAttribute = XNode.create(DOM_ATTRIBUTE_NODE, name, value, this);
+        newAttribute.transformedNodeName = name;
+        newAttribute.transformedNodeValue = value;
+        this.transformedAttributes.push(newAttribute);
     }
 
     setAttributeNS(namespace: any, name: any, value: any) {

--- a/src/dom/xnode.ts
+++ b/src/dom/xnode.ts
@@ -309,10 +309,11 @@ export class XNode {
         this.attributes.push(XNode.create(DOM_ATTRIBUTE_NODE, name, value, this));
     }
 
-    setTransformedAttribute(name: any, value: any) {
+    setTransformedAttribute(name: string, value: any) {
         for (let i = 0; i < this.transformedAttributes.length; ++i) {
-            if (this.transformedAttributes[i].nodeName == name) {
-                this.transformedAttributes[i].nodeValue = `${value}`;
+            if (this.transformedAttributes[i].nodeName === name) {
+                this.transformedAttributes[i].transformedNodeName = name;
+                this.transformedAttributes[i].transformedNodeValue = `${value}`;
                 return;
             }
         }

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -567,10 +567,15 @@ export class Xslt {
             node.transformedNodeName = template.nodeName;
             node.transformedLocalName = template.localName;
 
-            for (const attribute of template.attributes.filter((a: any) => a)) {
-                const name = attribute.nodeName;
-                const value = this.xsltAttributeValue(attribute.nodeValue, elementContext);
-                domSetTransformedAttribute(node, name, value);
+            const templateAttributes = template.attributes.filter((a: any) => a);
+            if (templateAttributes.length === 0) {
+                node.transformedAttributes = [];
+            } else {
+                for (const attribute of templateAttributes) {
+                    const name = attribute.nodeName;
+                    const value = this.xsltAttributeValue(attribute.nodeValue, elementContext);
+                    domSetTransformedAttribute(node, name, value);
+                }
             }
 
             this.xsltChildNodes(context, template, node, _parameters);

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -550,14 +550,16 @@ export class Xslt {
                     let node = textNodeList[0];
                     node.transformedNodeValue = template.nodeValue;
                 } else {
-                    let node = domCreateTextNode(outputDocument, template.nodeValue);
+                    let node = domCreateTransformedTextNode(outputDocument, template.nodeValue);
                     domAppendTransformedChild(context.nodelist[context.position], node);
                 }
             }
         } else if (template.nodeType == DOM_ELEMENT_NODE) {
             let node: XNode;
+            let elementContext = context;
             if (context.nodelist[context.position].nodeName === '#document') {
                 node = context.nodelist[context.position].firstChild;
+                elementContext = context.clone([node], 0);
             } else {
                 node = context.nodelist[context.position];
             }
@@ -567,7 +569,7 @@ export class Xslt {
 
             for (const attribute of template.attributes.filter((a: any) => a)) {
                 const name = attribute.nodeName;
-                const value = this.xsltAttributeValue(attribute.nodeValue, context);
+                const value = this.xsltAttributeValue(attribute.nodeValue, elementContext);
                 domSetTransformedAttribute(node, name, value);
             }
 

--- a/tests/xslt.test.tsx
+++ b/tests/xslt.test.tsx
@@ -87,6 +87,49 @@ describe('xslt', () => {
         });
     });
 
+    describe('xsl:template', () => {
+        it('Trivial', () => {
+            const xmlString = (
+                <root>
+                    <typeA />
+                    <typeB />
+                </root>
+            );
+
+            const xsltString = <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:output method="xml" version="1.0" encoding="utf-8" indent="yes" />
+                <xsl:template match="*|/*">
+                    <outputUnknown original-name="{name(.)}">
+                        <xsl:apply-templates select="*" />
+                    </outputUnknown>
+                </xsl:template>
+                <xsl:template match="typeA">
+                    <outputA />
+                </xsl:template>
+                <xsl:template match="/*/typeB">
+                    <outputB>I have text!</outputB>
+                </xsl:template>
+            </xsl:stylesheet>
+
+            const expectedOutString = (
+                <outputUnknown original-name="root">
+                    <outputA />
+                    <outputB>I have text!</outputB>
+                </outputUnknown>
+            );
+
+            const xsltClass = new Xslt();
+            const xml = xmlParse(xmlString);
+            const xslt = xmlParse(xsltString);
+            const outXmlString = xsltClass.xsltProcess(
+                xml,
+                xslt
+            );
+
+            assert.equal(outXmlString, expectedOutString);
+        });
+    });
+
     describe('xsl:text', () => {
         it('disable-output-escaping', () => {
             const xml = <anything></anything>;

--- a/tests/xslt.test.tsx
+++ b/tests/xslt.test.tsx
@@ -111,12 +111,11 @@ describe('xslt', () => {
                 </xsl:template>
             </xsl:stylesheet>
 
-            const expectedOutString = (
-                <outputUnknown original-name="root">
-                    <outputA />
-                    <outputB>I have text!</outputB>
-                </outputUnknown>
-            );
+            // Needs to be this way. `isomorphic-jsx rewrites `<outputA />` as `<outputA></outputA>`.
+            const expectedOutString = `<outputUnknown original-name="root">`+
+                `<outputA/>`+
+                `<outputB>I have text!</outputB>`+
+            `</outputUnknown>`;
 
             const xsltClass = new Xslt();
             const xml = xmlParse(xmlString);


### PR DESCRIPTION
- Resolves #49 

# Some thoughts

This:

```
<xsl:template match="*|/*">
```

Makes the processor visit all the tags recursively. This was setting `original-name` in all tags. This PR clears all the previous transformed attributes when no attributes are set in the next template. 
