### PR TITLE
HTML input with `<!DOCTYPE html>` defined returns empty output.

### DIFF
--- a/src/xpath/match-resolver.ts
+++ b/src/xpath/match-resolver.ts
@@ -96,7 +96,7 @@ export class MatchResolver {
      * @returns The list of found nodes.
      */
     private absoluteXsltMatch(expression: LocationExpr, context: ExprContext): XNode[] {
-        const firstChildOfRoot = context.root.childNodes[0];
+        const firstChildOfRoot = context.root.childNodes.find(c => c.nodeName !== '#dtd-section');
         const clonedContext = context.clone([firstChildOfRoot], undefined, 0, undefined);
         const matchedNodes = expression.evaluate(clonedContext).nodeSetValue();
         const finalList = [];
@@ -105,7 +105,7 @@ export class MatchResolver {
         // considered.
         let nodeList: XNode[];
         if (context.nodeList.length === 1 && context.nodeList[0].nodeName === '#document') {
-            nodeList = [context.nodeList[0].childNodes[0]];
+            nodeList = [context.nodeList[0].childNodes.find(c => c.nodeName !== '#dtd-section')];
         } else {
             nodeList = context.nodeList;
         }

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -710,7 +710,6 @@ export class Xslt {
             let node: XNode;
             let elementContext = context;
             if (context.nodeList[context.position].nodeName === '#document') {
-                // node = context.nodeList[context.position].firstChild;
                 node = context.nodeList[context.position].childNodes.find(c => c.nodeName !== '#dtd-section');
                 elementContext = context.clone([node]);
             } else {

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -710,7 +710,8 @@ export class Xslt {
             let node: XNode;
             let elementContext = context;
             if (context.nodeList[context.position].nodeName === '#document') {
-                node = context.nodeList[context.position].firstChild;
+                // node = context.nodeList[context.position].firstChild;
+                node = context.nodeList[context.position].childNodes.find(c => c.nodeName !== '#dtd-section');
                 elementContext = context.clone([node]);
             } else {
                 node = context.nodeList[context.position];

--- a/tests/html-to-lmht.test.tsx
+++ b/tests/html-to-lmht.test.tsx
@@ -1465,7 +1465,8 @@ describe('HTML to LMHT', () => {
                 </xsl:transform>
             );
 
-        const xmlString = (
+        const xmlString = '<!DOCTYPE html>' +
+        (
             <html>
                 <head>
                     <title>Teste</title>


### PR DESCRIPTION
Resolves #72 

DTD tags should *not* be considered for:

- Template matching;
- Defining first valid child from `#document`.