### PR TITLE
`upper-case` and `lower-case` (XSLT 2.0)

### DIFF
--- a/src/xpath/expr-context.ts
+++ b/src/xpath/expr-context.ts
@@ -88,6 +88,7 @@ export class ExprContext {
     constructor(
         nodeList: XNode[],
         outputNodeList: XNode[],
+        xsltVersion: '1.0' | '2.0' | '3.0' = '1.0',
         opt_position?: number,
         opt_outputPosition?: number,
         opt_outputDepth?: number,
@@ -102,6 +103,8 @@ export class ExprContext {
     ) {
         this.nodeList = nodeList;
         this.outputNodeList = outputNodeList;
+        this.xsltVersion = xsltVersion;
+
         this.position = opt_position || 0;
         this.outputPosition = opt_outputPosition || 0;
 
@@ -158,6 +161,7 @@ export class ExprContext {
         return new ExprContext(
             opt_nodeList || this.nodeList,
             opt_outputNodeList || this.outputNodeList,
+            this.xsltVersion,
             typeof opt_position !== 'undefined' ? opt_position : this.position,
             typeof opt_outputPosition !== 'undefined' ? opt_outputPosition : this.outputPosition,
             this.outputDepth,
@@ -176,6 +180,7 @@ export class ExprContext {
         return new ExprContext(
             this.nodeList,
             opt_outputNodeList || this.outputNodeList,
+            this.xsltVersion,
             this.position,
             typeof opt_outputPosition !== 'undefined' ? opt_outputPosition : this.outputPosition,
             typeof opt_outputDepth !== 'undefined' ? opt_outputDepth : this.outputDepth,

--- a/src/xpath/expressions/function-call-expr.ts
+++ b/src/xpath/expressions/function-call-expr.ts
@@ -35,6 +35,7 @@ import {
     formatNumber
 } from '../functions';
 import { extCardinal, extIf, extJoin } from '../functions/non-standard';
+import { lowerCase, upperCase } from '../functions/standard-20';
 import { BooleanValue } from '../values/boolean-value';
 import { Expression } from './expression';
 
@@ -58,6 +59,7 @@ export class FunctionCallExpr extends Expression {
         lang,
         last,
         'local-name': localName,
+        'lower-case': lowerCase,
         matches,
         name: _name,
         'namespace-uri': namespaceUri,
@@ -76,6 +78,7 @@ export class FunctionCallExpr extends Expression {
         'string-length': stringLength,
         translate,
         true: _true,
+        'upper-case': upperCase,
 
         // TODO(mesch): The following functions are custom. There is a
         // standard that defines how to add functions, which should be

--- a/src/xpath/functions/standard-20.ts
+++ b/src/xpath/functions/standard-20.ts
@@ -1,0 +1,15 @@
+import { ExprContext } from "../expr-context";
+import { StringValue } from "../values";
+import { assert } from "./internal-functions";
+
+export function upperCase(context: ExprContext) {
+    assert(['2.0', '3.0'].includes(context.xsltVersion));
+    const str: string = this.args[0].evaluate(context).stringValue();
+    return new StringValue(str.toUpperCase());
+}
+
+export function lowerCase(context: ExprContext) {
+    assert(['2.0', '3.0'].includes(context.xsltVersion));
+    const str: string = this.args[0].evaluate(context).stringValue();
+    return new StringValue(str.toLowerCase());
+}

--- a/src/xpath/values/boolean-value.ts
+++ b/src/xpath/values/boolean-value.ts
@@ -9,7 +9,7 @@ export class BooleanValue implements NodeValue {
         this.type = 'boolean';
     }
 
-    stringValue() {
+    stringValue(): string {
         return `${this.value}`;
     }
 

--- a/src/xpath/values/node-set-value.ts
+++ b/src/xpath/values/node-set-value.ts
@@ -10,7 +10,7 @@ export class NodeSetValue implements NodeValue {
         this.type = 'node-set';
     }
 
-    stringValue() {
+    stringValue(): string {
         if (this.value.length === 0) {
             return '';
         }

--- a/src/xpath/values/number-value.ts
+++ b/src/xpath/values/number-value.ts
@@ -9,7 +9,7 @@ export class NumberValue implements NodeValue {
         this.type = 'number';
     }
 
-    stringValue() {
+    stringValue(): string {
         return `${this.value}`;
     }
 

--- a/src/xpath/values/string-value.ts
+++ b/src/xpath/values/string-value.ts
@@ -9,8 +9,8 @@ export class StringValue implements NodeValue {
         this.type = 'string';
     }
 
-    stringValue() {
-        return this.value;
+    stringValue(): string {
+        return String(this.value);
     }
 
     booleanValue() {

--- a/tests/xpath/functions.test.tsx
+++ b/tests/xpath/functions.test.tsx
@@ -21,245 +21,268 @@ describe('XPath Functions', () => {
         xmlParser = new XmlParser();
     });
 
-    it('current', () => {
-        const xml = xmlParser.xmlParse(<root>test</root>);
-        const xsltDefinition = xmlParser.xmlParse(
-            <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                <xsl:template match="/">
-                    <xsl:value-of select="current()"/>
-                </xsl:template>
-            </xsl:stylesheet>
-        );
-
-        const xsltClass = new Xslt();
-        const outXmlString = xsltClass.xsltProcess(
-            xml,
-            xsltDefinition
-        );
-
-        assert.equal(outXmlString, 'test');
-    });
-
-    describe('format-number', () => {
-        xmlParser = new XmlParser();
-        const xml = xmlParser.xmlParse(<root></root>);
-
-        it('Trivial', () => {
+    describe('1.0', () => {
+        it('current', () => {
+            const xml = xmlParser.xmlParse(<root>test</root>);
             const xsltDefinition = xmlParser.xmlParse(
                 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
                     <xsl:template match="/">
-                        <xsl:value-of select="format-number(500100, '#')"/>
+                        <xsl:value-of select="current()" />
                     </xsl:template>
                 </xsl:stylesheet>
             );
 
             const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
+            const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
 
-            assert.equal(outXmlString, '500100');
+            assert.equal(outXmlString, 'test');
         });
 
-        it('Decimal, only integer part', () => {
+        describe('format-number', () => {
+            xmlParser = new XmlParser();
+            const xml = xmlParser.xmlParse(<root></root>);
+
+            it('Trivial', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number(500100, '#')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, '500100');
+            });
+
+            it('Decimal, only integer part', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number(500100.20, '#')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, '500100');
+            });
+
+            it('Decimal, everything', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number(500100.20, '#.#')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, '500100.2');
+            });
+
+            it('Decimal, mask with thousand separator, everything', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number(500100.20, '###,###.#')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, '500,100.2');
+            });
+
+            it('Decimal, mask with filling zeroes', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number(500100.20, '#.000')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, '500100.200');
+            });
+
+            it('NaN', () => {
+                const xsltDefinition = xmlParser.xmlParse(
+                    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                        <xsl:template match="/">
+                            <xsl:value-of select="format-number('test', '#')" />
+                        </xsl:template>
+                    </xsl:stylesheet>
+                );
+
+                const xsltClass = new Xslt();
+                const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
+
+                assert.equal(outXmlString, 'NaN');
+            });
+        });
+
+        it('generate-id, trivial', () => {
+            const xml = xmlParser.xmlParse(<root></root>);
             const xsltDefinition = xmlParser.xmlParse(
                 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
                     <xsl:template match="/">
-                        <xsl:value-of select="format-number(500100.20, '#')"/>
-                    </xsl:template>
-                </xsl:stylesheet>
-            );
-
-            const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
-
-            assert.equal(outXmlString, '500100');
-        });
-
-        it('Decimal, everything', () => {
-            const xsltDefinition = xmlParser.xmlParse(
-                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                    <xsl:template match="/">
-                        <xsl:value-of select="format-number(500100.20, '#.#')"/>
-                    </xsl:template>
-                </xsl:stylesheet>
-            );
-
-            const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
-
-            assert.equal(outXmlString, '500100.2');
-        });
-
-        it('Decimal, mask with thousand separator, everything', () => {
-            const xsltDefinition = xmlParser.xmlParse(
-                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                    <xsl:template match="/">
-                        <xsl:value-of select="format-number(500100.20, '###,###.#')"/>
-                    </xsl:template>
-                </xsl:stylesheet>
-            );
-
-            const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
-
-            assert.equal(outXmlString, '500,100.2');
-        });
-
-        it('Decimal, mask with filling zeroes', () => {
-            const xsltDefinition = xmlParser.xmlParse(
-                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                    <xsl:template match="/">
-                        <xsl:value-of select="format-number(500100.20, '#.000')"/>
-                    </xsl:template>
-                </xsl:stylesheet>
-            );
-
-            const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
-
-            assert.equal(outXmlString, '500100.200');
-        });
-
-        it('NaN', () => {
-            const xsltDefinition = xmlParser.xmlParse(
-                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                    <xsl:template match="/">
-                        <xsl:value-of select="format-number('test', '#')"/>
-                    </xsl:template>
-                </xsl:stylesheet>
-            );
-
-            const xsltClass = new Xslt();
-            const outXmlString = xsltClass.xsltProcess(
-                xml,
-                xsltDefinition
-            );
-
-            assert.equal(outXmlString, 'NaN');
-        });
-    });
-
-    it('generate-id, trivial', () => {
-        const xml = xmlParser.xmlParse(<root></root>);
-        const xsltDefinition = xmlParser.xmlParse(
-            <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                <xsl:template match="/">
-                    <xsl:attribute name="uid">
-                        <xsl:value-of select="generate-id(.)"/>
-                    </xsl:attribute>
-                </xsl:template>
-            </xsl:stylesheet>
-        );
-
-        const xsltClass = new Xslt();
-
-        const outXmlString = xsltClass.xsltProcess(
-            xml,
-            xsltDefinition
-        );
-
-        assert.ok(outXmlString);
-    });
-
-    it.skip('generate-id, complete', () => {
-        const xsltDefinition = xmlParser.xmlParse(
-            <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-                <xsl:output method="xml" omit-xml-declaration="yes"/>
-
-                <xsl:template match="chapter | sect1 | sect2">
-                    <xsl:copy>
                         <xsl:attribute name="uid">
-                            <xsl:value-of select="generate-id(.)"/>
+                            <xsl:value-of select="generate-id(.)" />
                         </xsl:attribute>
-                        <xsl:apply-templates select="@*|node()"/>
-                    </xsl:copy>
-                </xsl:template>
+                    </xsl:template>
+                </xsl:stylesheet>
+            );
 
-                <xsl:template match="@*|node()">
-                    <xsl:copy>
-                        <xsl:apply-templates select="@*|node()"/>
-                    </xsl:copy>
-                </xsl:template>
+            const xsltClass = new Xslt();
 
-            </xsl:stylesheet>
-        );
+            const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
 
-        const xml = xmlParser.xmlParse(
-            <chapter>
-                <para>Then with expanded wings he steers his flight</para>
-                <figure>
-                    <title>"Incumbent on the Dusky Air"</title>
-                    <graphic fileref="pic1.jpg"/>
-                </figure>
-                <para>Aloft, incumbent on the dusky Air</para>
-                <sect1>
-                    <para>That felt unusual weight, till on dry Land</para>
+            assert.ok(outXmlString);
+        });
+
+        it.skip('generate-id, complete', () => {
+            const xsltDefinition = xmlParser.xmlParse(
+                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+                    <xsl:output method="xml" omit-xml-declaration="yes" />
+
+                    <xsl:template match="chapter | sect1 | sect2">
+                        <xsl:copy>
+                            <xsl:attribute name="uid">
+                                <xsl:value-of select="generate-id(.)" />
+                            </xsl:attribute>
+                            <xsl:apply-templates select="@*|node()" />
+                        </xsl:copy>
+                    </xsl:template>
+
+                    <xsl:template match="@*|node()">
+                        <xsl:copy>
+                            <xsl:apply-templates select="@*|node()" />
+                        </xsl:copy>
+                    </xsl:template>
+                </xsl:stylesheet>
+            );
+
+            const xml = xmlParser.xmlParse(
+                <chapter>
+                    <para>Then with expanded wings he steers his flight</para>
                     <figure>
-                        <title>"He Lights"</title>
-                        <graphic fileref="pic2.jpg"/>
+                        <title>"Incumbent on the Dusky Air"</title>
+                        <graphic fileref="pic1.jpg" />
                     </figure>
-                    <para>He lights, if it were Land that ever burned</para>
-                    <sect2>
-                        <para>With solid, as the Lake with liquid fire</para>
+                    <para>Aloft, incumbent on the dusky Air</para>
+                    <sect1>
+                        <para>That felt unusual weight, till on dry Land</para>
                         <figure>
-                            <title>"The Lake with Liquid Fire"</title>
-                            <graphic fileref="pic3.jpg"/>
+                            <title>"He Lights"</title>
+                            <graphic fileref="pic2.jpg" />
                         </figure>
-                    </sect2>
-                </sect1>
-            </chapter>
-        );
+                        <para>He lights, if it were Land that ever burned</para>
+                        <sect2>
+                            <para>With solid, as the Lake with liquid fire</para>
+                            <figure>
+                                <title>"The Lake with Liquid Fire"</title>
+                                <graphic fileref="pic3.jpg" />
+                            </figure>
+                        </sect2>
+                    </sect1>
+                </chapter>
+            );
 
-        const xsltClass = new Xslt();
+            const xsltClass = new Xslt();
 
-        const outXmlString = xsltClass.xsltProcess(
-            xml,
-            xsltDefinition
-        );
+            const outXmlString = xsltClass.xsltProcess(xml, xsltDefinition);
 
-        console.log(outXmlString)
-        assert.ok(!outXmlString);
+            // Uncomment below to see the results
+            // console.log(outXmlString);
+            assert.ok(!outXmlString);
+        });
+
+        it('translate', () => {
+            const xmlString = (
+                <root>
+                    <typeA />
+                    <typeB />
+                </root>
+            );
+
+            const xsltString = (
+                <xsl:template match="/">
+                    <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'" />
+                    <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+                    <xsl:value-of select="translate(DELETED, $smallcase, $uppercase)" />
+                </xsl:template>
+            );
+
+            const xsltClass = new Xslt();
+
+            const xml = xmlParser.xmlParse(xmlString);
+            const xslt = xmlParser.xmlParse(xsltString);
+
+            const outXmlString = xsltClass.xsltProcess(xml, xslt);
+
+            // Uncomment below to see the results
+            // console.log(outXmlString);
+            assert.ok(!outXmlString);
+        });
     });
 
-    it('translate', () => {
-        const xmlString = (
-            <root>
-                <typeA />
-                <typeB />
-            </root>
-        );
+    describe('2.0', () => {
+        it('upper-case', () => {
+            const xmlString = (
+                <root></root>
+            );
 
-        const xsltString = <xsl:template match="/">
-            <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'" />
-            <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
-            <xsl:value-of select="translate(DELETED, $smallcase, $uppercase)" />
-        </xsl:template>
+            const xsltString = (
+                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+                    <xsl:template match="/">
+                        <xsl:value-of select="upper-case('Lily')" />
+                    </xsl:template>
+                </xsl:stylesheet>
+            )
 
-        const xsltClass = new Xslt();
+            const xsltClass = new Xslt();
 
-        const xml = xmlParser.xmlParse(xmlString);
-        const xslt = xmlParser.xmlParse(xsltString);
+            const xml = xmlParser.xmlParse(xmlString);
+            const xslt = xmlParser.xmlParse(xsltString);
 
-        const outXmlString = xsltClass.xsltProcess(
-            xml,
-            xslt
-        );
+            const outXmlString = xsltClass.xsltProcess(xml, xslt);
 
-        console.log(outXmlString)
-        assert.ok(!outXmlString);
-    })
+            assert.equal(outXmlString, 'LILY');
+        });
+
+        it('lower-case', () => {
+            const xmlString = (
+                <root></root>
+            );
+
+            const xsltString = (
+                <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+                    <xsl:template match="/">
+                        <xsl:value-of select="lower-case('Lily')" />
+                    </xsl:template>
+                </xsl:stylesheet>
+            )
+
+            const xsltClass = new Xslt();
+
+            const xml = xmlParser.xmlParse(xmlString);
+            const xslt = xmlParser.xmlParse(xsltString);
+
+            const outXmlString = xsltClass.xsltProcess(xml, xslt);
+
+            assert.equal(outXmlString, 'lily');
+        });
+    });
 });


### PR DESCRIPTION
- Resolves #33;
- Only works for XSLT version 2.0. Otherwise, it gives an `Assertion failed` error.