### PR TITLE
Partially implementing `<xsl:import>`.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,6 @@ XSLT-processor TODO
 * XSL:number
 * `attribute-set`, `decimal-format`, etc. (check `src/xslt.ts`)
 * `/html/body//ul/li|html/body//ol/li` has `/html/body//ul/li` evaluated by this XPath implementation as "absolute", and `/html/body//ol/li` as "relative". Both should be evaluated as "absolute".
+* Implement `<xsl:import>` with correct template precedence.
 
 Help is much appreciated. It seems to currently work for most of our purposes, but fixes and additions are always welcome!

--- a/tests/xslt/import.test.tsx
+++ b/tests/xslt/import.test.tsx
@@ -1,0 +1,39 @@
+import assert from 'assert';
+
+import { XmlParser } from "../../src/dom";
+import { Xslt } from "../../src/xslt";
+
+describe('xsl:import', () => {
+    it('Trivial', async () => {
+        const xmlSource = `<html></html>`;
+
+        const xsltSource = `<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+            <xsl:output method="html" indent="yes"/>
+            <xsl:import href="https://raw.githubusercontent.com/DesignLiquido/xslt-processor/main/examples/head.xsl"/>
+        </xsl:stylesheet>`;
+
+        const xsltClass = new Xslt();
+        const xmlParser = new XmlParser();
+        const xml = xmlParser.xmlParse(xmlSource);
+        const xslt = xmlParser.xmlParse(xsltSource);
+        const resultingXml = await xsltClass.xsltProcess(xml, xslt);
+        assert.equal(resultingXml, '<html><head><link rel="stylesheet" type="text/css" href="style.css"><title/></head><body><div id="container"><div id="header"><div id="menu"><ul><li><a href="#" class="active">Home</a></li><li><a href="#">about</a></li></ul></div></div></div></body></html>');
+    });
+
+    it('Not the first child of `<xsl:stylesheet>` or `<xsl:transform>`', async () => {
+        const xmlSource = `<html></html>`;
+
+        const xsltSource = `<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+            <xsl:template match="/">
+                Anything
+            </xsl:template>
+            <xsl:import href="https://raw.githubusercontent.com/DesignLiquido/xslt-processor/main/examples/head.xsl"/>
+        </xsl:stylesheet>`;
+
+        const xsltClass = new Xslt();
+        const xmlParser = new XmlParser();
+        const xml = xmlParser.xmlParse(xmlSource);
+        const xslt = xmlParser.xmlParse(xsltSource);
+        assert.rejects(async () => await xsltClass.xsltProcess(xml, xslt));
+    });
+});


### PR DESCRIPTION
Template precedence is not implemented yet. Maybe in the future, with some clear examples showing the differences between `<xsl:import>` and `<xsl:include>`.