### PR TITLE
Correct `disable-output-escaping` implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const xslt = new Xslt(options);
 ```
 
 - `cData` (`boolean`, default `true`): resolves CDATA elements in the output. Content under CDATA is resolved as text. This overrides `escape` for CDATA content.
-- `escape` (`boolean`, default `true`): replaces symbols like `<`, `>`, `&` and `"` by the corresponding [XML entities](https://www.tutorialspoint.com/xml/xml_character_entities.htm).
+- `escape` (`boolean`, default `true`): replaces symbols like `<`, `>`, `&` and `"` by the corresponding [HTML/XML entities](https://www.tutorialspoint.com/xml/xml_character_entities.htm). Can be overridden by `disable-output-escaping`, that also does the opposite, unescaping `&gt;` and `&lt;` by `<` and `>`, respectively.
 - `selfClosingTags` (`boolean`, default `true`): Self-closes tags that don't have inner elements, if `true`. For instance, `<test></test>` becomes `<test />`.
 - `outputMethod` (`string`, default `xml`): Specifies the default output method. if `<xsl:output>` is declared in your XSLT file, this will be overridden.
 - `parameters` (`array`, default `[]`): external parameters that you want to use.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,14 @@
 XSLT-processor TODO
 =====
 
-* Rethink match algorithm, as described in https://github.com/DesignLiquido/xslt-processor/pull/62#issuecomment-1636684453;
+* Rethink match algorithm, as described in https://github.com/DesignLiquido/xslt-processor/pull/62#issuecomment-1636684453. There's a good number of issues open about this problem:
+    * https://github.com/DesignLiquido/xslt-processor/issues/108
+    * https://github.com/DesignLiquido/xslt-processor/issues/109
+    * https://github.com/DesignLiquido/xslt-processor/issues/110
 * XSLT validation, besides the version number;
 * XSL:number
 * `attribute-set`, `decimal-format`, etc. (check `src/xslt.ts`)
-* `/html/body//ul/li|html/body//ol/li` has `/html/body//ul/li` evaluated by this XPath implementation as "absolute", and `/html/body//ol/li` as "relative". Both should be evaluated as "absolute".
-* Implement `<xsl:import>` with correct template precedence.
+* `/html/body//ul/li|html/body//ol/li` has `/html/body//ul/li` evaluated by this XPath implementation as "absolute", and `/html/body//ol/li` as "relative". Both should be evaluated as "absolute". One idea is to rewrite the XPath logic entirely, since it is nearly impossible to debug it.
+* Implement `<xsl:import>` with correct template precedence. 
 
 Help is much appreciated. It seems to currently work for most of our purposes, but fixes and additions are always welcome!

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@rollup/plugin-typescript": "^11.1.1",
     "@types/he": "^1.2.0",
     "@types/jest": "^29.5.12",
+    "@types/node-fetch": "^2.6.11",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "babel-jest": "^29.7.0",

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -3,4 +3,5 @@ export * from './xdocument';
 export * from './xml-functions';
 export * from './xml-output-options';
 export * from './xml-parser';
+export * from './xbrowser-node';
 export * from './xnode';

--- a/src/dom/xbrowser-node.ts
+++ b/src/dom/xbrowser-node.ts
@@ -1,0 +1,10 @@
+import { XNode } from "./xnode";
+
+/**
+ * Special XNode class, that retains properties from browsers like 
+ * IE, Opera, Safari, etc.
+ */
+export class XBrowserNode extends XNode {
+    innerText?: string;
+    textContent?: string;
+}

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -24,7 +24,7 @@ import {
     xmlGetAttribute,
     xmlTransformedText,
     xmlValue,
-    xmlValue2
+    xmlValueLegacyBehavior
 } from '../dom';
 import { ExprContext, XPath } from '../xpath';
 
@@ -366,7 +366,7 @@ export class Xslt {
 
         const documentFragment = domCreateDocumentFragment(this.outputDocument);
         await this.xsltChildNodes(context, template, documentFragment);
-        const value = xmlValue2(documentFragment);
+        const value = xmlValueLegacyBehavior(documentFragment);
 
         if (output && output.nodeType === DOM_DOCUMENT_FRAGMENT_NODE) {
             domSetTransformedAttribute(output, name, value);

--- a/tests/xslt/xslt.test.tsx
+++ b/tests/xslt/xslt.test.tsx
@@ -199,12 +199,38 @@ describe('xslt', () => {
     });
 
     describe('xsl:text', () => {
-        it('disable-output-escaping', async () => {
+        // Apparently, this is not how `disable-output-escaping` works. 
+        // By an initial research, `<!DOCTYPE html>` explicitly mentioned in 
+        // the XSLT gives an error like: 
+        // `Unable to generate the XML document using the provided XML/XSL input. 
+        // org.xml.sax.SAXParseException; lineNumber: 4; columnNumber: 70; 
+        // A DOCTYPE is not allowed in content.`
+        // All the examples of `disable-output-escaping` usage will point out
+        // the opposite: `&lt;!DOCTYPE html&gt;` will become `<!DOCTYPE html>`.
+        // This test will be kept here for historical purposes.
+        it.skip('disable-output-escaping', async () => {
             const xml = `<anything></anything>`;
             const xslt = `<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
                 <xsl:output method="html" indent="yes" />
                 <xsl:template match="/">
                     <xsl:text disable-output-escaping="yes"><!DOCTYPE html></xsl:text>
+                </xsl:template>
+            </xsl:stylesheet>`;
+
+            const xsltClass = new Xslt();
+            const xmlParser = new XmlParser();
+            const parsedXml = xmlParser.xmlParse(xml);
+            const parsedXslt = xmlParser.xmlParse(xslt);
+            const html = await xsltClass.xsltProcess(parsedXml, parsedXslt);
+            assert.equal(html, '<!DOCTYPE html>');
+        });
+
+        it('disable-output-escaping, XML/HTML entities', async () => {
+            const xml = `<anything></anything>`;
+            const xslt = `<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:output method="html" indent="yes" />
+                <xsl:template match="/">
+                    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
                 </xsl:template>
             </xsl:stylesheet>`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,6 +1886,14 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/node-fetch@^2.6.11":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node@*":
   version "22.5.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.4.tgz#83f7d1f65bc2ed223bdbf57c7884f1d5a4fa84e8"


### PR DESCRIPTION
- Resolving https://github.com/DesignLiquido/xslt-processor/issues/111;
- Adding `XBrowserNode` to deal with browser-generated nodes with extra properties;
- Additional comments and notes at TODO and README files.