### PR TITLE
Adding `xhtml` option to `outputMethod`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const xslt = new Xslt(options);
 - `cData` (`boolean`, default `true`): resolves CDATA elements in the output. Content under CDATA is resolved as text. This overrides `escape` for CDATA content.
 - `escape` (`boolean`, default `true`): replaces symbols like `<`, `>`, `&` and `"` by the corresponding [HTML/XML entities](https://www.tutorialspoint.com/xml/xml_character_entities.htm). Can be overridden by `disable-output-escaping`, that also does the opposite, unescaping `&gt;` and `&lt;` by `<` and `>`, respectively.
 - `selfClosingTags` (`boolean`, default `true`): Self-closes tags that don't have inner elements, if `true`. For instance, `<test></test>` becomes `<test />`.
-- `outputMethod` (`string`, default `xml`): Specifies the default output method. if `<xsl:output>` is declared in your XSLT file, this will be overridden.
+- `outputMethod` (`string`, default `xml`): Specifies the default output method. if `<xsl:output>` is declared in your XSLT file, this will be overridden. Valid values: `xml`, `html`, `text`, `name`, `xhtml`.
 - `parameters` (`array`, default `[]`): external parameters that you want to use.
     - `name`: the parameter name;
     - `namespaceUri` (optional): the namespace;

--- a/src/dom/xml-output-options.ts
+++ b/src/dom/xml-output-options.ts
@@ -2,5 +2,5 @@ export type XmlOutputOptions = {
     cData: boolean;
     escape: boolean;
     selfClosingTags: boolean;
-    outputMethod: 'xml' | 'html' | 'text' | 'name'
+    outputMethod: 'xml' | 'html' | 'text' | 'name' | 'xhtml';
 }

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -73,7 +73,7 @@ export class Xslt {
     decimalFormatSettings: XsltDecimalFormatSettings;
 
     outputDocument: XDocument;
-    outputMethod: 'xml' | 'html' | 'text' | 'name';
+    outputMethod: 'xml' | 'html' | 'text' | 'name' | 'xhtml';
     outputOmitXmlDeclaration: string;
     version: string;
     firstTemplateRan: boolean;


### PR DESCRIPTION
Resolves https://github.com/DesignLiquido/xslt-processor/issues/127