### PR TITLE
In HTML output mode, special handling for `xmlns` and `xmlns:*`.

### DIFF
--- a/src/dom/xml-functions.ts
+++ b/src/dom/xml-functions.ts
@@ -317,6 +317,12 @@ function xmlElementLogicTrivial(node: XNode, buffer: string[], options: XmlOutpu
             continue;
         }
 
+        // In HTML output mode, skip namespace declarations (xmlns and xmlns:*)
+        if (options.outputMethod === 'html' && 
+            (attribute.nodeName === 'xmlns' || attribute.nodeName.startsWith('xmlns:'))) {
+            continue;
+        }
+
         if (attribute.nodeName && attribute.nodeValue !== null && attribute.nodeValue !== undefined) {
             buffer.push(` ${xmlFullNodeName(attribute)}="${xmlEscapeAttr(attribute.nodeValue)}"`);
         }

--- a/src/xslt/xslt.ts
+++ b/src/xslt/xslt.ts
@@ -4979,6 +4979,12 @@ export class Xslt {
                     } else if (namespaceUri) {
                         domSetAttribute(newNode, `xmlns:${aliasPrefix}`, namespaceUri);
                     }
+                } else if (namespaceUri) {
+                    const prefix = templatePrefix || (qualifiedName.includes(':') ? qualifiedName.split(':')[0] : null);
+                    const nsAttr = prefix ? `xmlns:${prefix}` : 'xmlns';
+                    if (!this.isNamespaceDeclaredOnAncestor(output, nsAttr, namespaceUri)) {
+                        domSetAttribute(newNode, nsAttr, namespaceUri);
+                    }
                 }
 
                 // Apply attribute sets from use-attribute-sets attribute on literal elements

--- a/tests/xslt/message-number-namespace.test.ts
+++ b/tests/xslt/message-number-namespace.test.ts
@@ -694,6 +694,46 @@ describe('Error messages for misplaced elements', () => {
     });
 });
 
+describe('Namespace declarations on literal result elements (issue #165)', () => {
+    it('Namespace-prefixed literal result element includes xmlns declaration', async () => {
+        const xmlString = `<?xml version="1.0"?><doc/>`;
+
+        const xsltString = `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:q="urn:Q" version="1.0">
+    <xsl:template match="/">
+        <q:text>Out</q:text>
+    </xsl:template>
+</xsl:stylesheet>`;
+
+        const xsltClass = new Xslt();
+        const xmlParser = new XmlParser();
+        const xml = xmlParser.xmlParse(xmlString);
+        const xslt = xmlParser.xmlParse(xsltString);
+
+        const outXmlString = await xsltClass.xsltProcess(xml, xslt);
+        assert.equal(outXmlString, '<q:text xmlns:q="urn:Q">Out</q:text>');
+    });
+
+    it('Nested namespace-prefixed elements do not duplicate xmlns declaration', async () => {
+        const xmlString = `<?xml version="1.0"?><doc/>`;
+
+        const xsltString = `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:q="urn:Q" version="1.0">
+    <xsl:template match="/">
+        <q:outer><q:inner>Text</q:inner></q:outer>
+    </xsl:template>
+</xsl:stylesheet>`;
+
+        const xsltClass = new Xslt();
+        const xmlParser = new XmlParser();
+        const xml = xmlParser.xmlParse(xmlString);
+        const xslt = xmlParser.xmlParse(xsltString);
+
+        const outXmlString = await xsltClass.xsltProcess(xml, xslt);
+        assert.equal(outXmlString, '<q:outer xmlns:q="urn:Q"><q:inner>Text</q:inner></q:outer>');
+    });
+});
+
 describe('Modes and Multiple Template Sets', () => {
     it('Template in non-default mode not selected if no mode specified', async () => {
         const xmlString = `<?xml version="1.0"?>


### PR DESCRIPTION
Resolves https://github.com/DesignLiquido/xslt-processor/issues/165